### PR TITLE
I477 central publishing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-10-25T08:41:43Z",
+  "generated_at": "2025-06-23T12:26:22Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -80,6 +80,7 @@
     "README.md": [
       {
         "hashed_secret": "fe568a3dee570ca32995a8e3cd6f2fc7010ad368",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
@@ -88,9 +89,10 @@
     ],
     "build.gradle": [
       {
-        "hashed_secret": "7ff464870a88a66277542abe28dd577aac8c89bb",
+        "hashed_secret": "52671c8abfb5a16b27e80d10952d43f0beff63d3",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 140,
+        "line_number": 139,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -98,6 +100,7 @@
     "sample/src/main/resources/application.properties": [
       {
         "hashed_secret": "fe568a3dee570ca32995a8e3cd6f2fc7010ad368",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 3,
         "type": "Secret Keyword",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
             version = readFile('VERSION').trim()
             isReleaseVersion = !version.toUpperCase(Locale.ENGLISH).contains("SNAPSHOT")
 
-            withCredentials([usernamePassword(credentialsId: 'ossrh', passwordVariable: 'OSSRH_PASSWORD', usernameVariable: 'OSSRH_USER'), 
+            withCredentials([usernamePassword(credentialsId: 'central-portal', passwordVariable: 'CP_PASSWORD', usernameVariable: 'CP_USER'), 
                             certificate(credentialsId: 'cldtsdks-signing-cert', keystoreVariable: 'CODE_SIGNING_PFX_FILE', passwordVariable: 'CODE_SIGNING_P12_PASSWORD')]) {
               sh '''
                 #!/bin/bash -e

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,9 +69,19 @@ pipeline {
                 gradle -Psigning.gnupg.keyName=$SIGNING_KEYID -Psigning.gnupg.executable=/opt/Garantir/bin/gpg -Psigning.gnupg.homeDir=$HOME/.gnupggrs publish
               '''
             }
-      
-            // if it is a release build then do the git tagging
+            // if it is a release build then do extra work
             if (isReleaseVersion) {
+              // Upload from OSSRH staging API to central portal and publish
+              httpRequest(
+                authentication: 'central-portal',
+                httpMode: 'POST',
+                responseHandle: 'NONE',
+                url: 'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.ibm.cloud?publishing_type=automatic',
+                validResponseCodes: '200',
+                wrapAsMultipart: false
+              )
+
+              // Create a git tag and a draft release
               gitTagAndPublish {
                 isDraft=true
                 releaseApiUrl='https://api.github.com/repos/IBM/cloudant-spring/releases'

--- a/build.gradle
+++ b/build.gradle
@@ -132,11 +132,11 @@ publishing {
     repositories {
         maven {
             url = isReleaseVersion ?
-                    "https://oss.sonatype.org/service/local/staging/deploy/maven2/" :
-                    "https://oss.sonatype.org/content/repositories/snapshots"
+                    'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/' :
+                    'https://central.sonatype.com/repository/maven-snapshots/'
             credentials(PasswordCredentials) {
-                username = System.env.OSSRH_USER
-                password = System.env.OSSRH_PASSWORD
+                username = System.env.CP_USER
+                password = System.env.CP_PASSWORD
             }
         }
     }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Added tests for code changes _or_ test/build only changes - CI
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes - CI
- [x] Completed the PR template below:

## Description

Use the Central Portal OSSRH Staging API to keep publishing using gradle `maven-publish`.

Fixes i477

## Approach

* Update creds for Central Portal token
* Update Maven repository URLs for Central Portal locations (OSSRH Staging API for releases, Central Portal snapshots for snapshots)
* Add a `POST` to `Jenkinsfile` to transfer content from OSSRH Staging API to Central Portal deployment with `automatic` publishing 🤞 

Once it merges we can validate that the snapshot part is working, but for the rest we need a real release to test.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
